### PR TITLE
Users/ryanb58/GitHub actions fix deprecated feature

### DIFF
--- a/.github/workflows/auto-export-and-deploy.yml
+++ b/.github/workflows/auto-export-and-deploy.yml
@@ -36,7 +36,7 @@ jobs:
         name: Get current datetime
         run: |
           $datetime = $(Get-Date -Format "yyyy-MM-ddTHH:mm:ss")
-          echo "::set-output name=datetime::$datetime"
+          echo "datetime=$datetime" >> "$GITHUB_ENV"
 
       - name: Setup .NET Core environment 
         uses: actions/setup-dotnet@v1
@@ -64,7 +64,7 @@ jobs:
           $lines = $output -split "`n"
           $versionLine = $lines | Where-Object { $_ -match "${{ github.event.inputs.solution_name }}" }
           $version = ($versionLine -split "\s+")[3]
-          echo "::set-output name=current_version::$version"
+          echo "current_version=$version" >> "$GITHUB_ENV"
           # Split the version into its components
           $versionParts = $version.Split('.')
           # Define an environment variable for the version part to increment
@@ -78,9 +78,9 @@ jobs:
           }
           # Reconstruct the version
           $newVersion = "{0}.{1}.{2}.{3}" -f $versionParts[0], $versionParts[1], $versionParts[2], $versionParts[3]
-          echo "::set-output name=new_version::$newVersion"
+          echo "new_version=$newVersion" >> "$GITHUB_ENV"
           $newVersionWithUnderscores = "{0}_{1}_{2}_{3}" -f $versionParts[0], $versionParts[1], $versionParts[2], $versionParts[3]
-          echo "::set-output name=new_version_with_underscores::$newVersionWithUnderscores"        
+          echo "new_version_with_underscores=$newVersionWithUnderscores" >> "$GITHUB_ENV"
 
       - name: Increment the online version
         run: pac solution online-version --solution-name "${{ github.event.inputs.solution_name }}" --solution-version ${{ steps.solution_versioning.outputs.new_version }}

--- a/.github/workflows/auto-export-and-deploy.yml
+++ b/.github/workflows/auto-export-and-deploy.yml
@@ -83,25 +83,25 @@ jobs:
           echo "new_version_with_underscores=$newVersionWithUnderscores" >> "$GITHUB_ENV"
 
       - name: Increment the online version
-        run: pac solution online-version --solution-name "${{ github.event.inputs.solution_name }}" --solution-version ${{ steps.solution_versioning.outputs.new_version }}
+        run: pac solution online-version --solution-name "${{ github.event.inputs.solution_name }}" --solution-version ${{ env.new_version }}
 
       - name: Export unmanaged solution
-        run: pac solution export --path "${{ github.event.inputs.solution_name }}_${{ steps.solution_versioning.outputs.new_version_with_underscores }}_unmanaged.zip" --name "${{ github.event.inputs.solution_name }}" --include general
+        run: pac solution export --path "${{ github.event.inputs.solution_name }}_${{ env.new_version_with_underscores }}_unmanaged.zip" --name "${{ github.event.inputs.solution_name }}" --include general
 
       - name: Export managed solution
-        run: pac solution export --path "${{ github.event.inputs.solution_name }}_${{ steps.solution_versioning.outputs.new_version_with_underscores }}_managed.zip" --name "${{ github.event.inputs.solution_name }}" --managed --include general
+        run: pac solution export --path "${{ github.event.inputs.solution_name }}_${{ env.new_version_with_underscores }}_managed.zip" --name "${{ github.event.inputs.solution_name }}" --managed --include general
 
       - name: Publish unmanaged artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.inputs.solution_name }}_${{ steps.solution_versioning.outputs.new_version_with_underscores }}_unmanaged
-          path: ${{ github.event.inputs.solution_name }}_${{ steps.solution_versioning.outputs.new_version_with_underscores }}_unmanaged.zip
+          name: ${{ github.event.inputs.solution_name }}_${{ env.new_version_with_underscores }}_unmanaged
+          path: ${{ github.event.inputs.solution_name }}_${{ env.new_version_with_underscores }}_unmanaged.zip
 
       - name: Publish managed artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.inputs.solution_name }}_${{ steps.solution_versioning.outputs.new_version_with_underscores }}_managed
-          path: ${{ github.event.inputs.solution_name }}_${{ steps.solution_versioning.outputs.new_version_with_underscores }}_managed.zip
+          name: ${{ github.event.inputs.solution_name }}_${{ env.new_version_with_underscores }}_managed
+          path: ${{ github.event.inputs.solution_name }}_${{ env.new_version_with_underscores }}_managed.zip
 
       - name: Auth with Source Environment
         run: |
@@ -114,4 +114,4 @@ jobs:
 
       - name: Deploy Managed version To Target Environment
         run: |
-          pac solution import --path "${{ github.event.inputs.solution_name }}_${{ steps.solution_versioning.outputs.new_version_with_underscores }}_managed.zip" --activate-plugins --publish-changes
+          pac solution import --path "${{ github.event.inputs.solution_name }}_${{ env.new_version_with_underscores }}_managed.zip" --activate-plugins --publish-changes

--- a/.github/workflows/export-to-branch.yml
+++ b/.github/workflows/export-to-branch.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions@github.com"
-          git checkout -b "${{ github.event.inputs.solution_name }}-${{ steps.date.outputs.date }}"
+          git checkout -b "${{ github.event.inputs.solution_name }}-${{ env.date }}"
           git add .
           git commit -m "Synced ${{ github.event.inputs.solution_name }} Power Platform Solution"
           git push --set-upstream origin "${{ github.event.inputs.solution_name }}-${{ steps.date.outputs.date }}"


### PR DESCRIPTION
GitHub is deprecating the set-store and set-output functionality in replacement of using environment files. This PR addresses that change in our own repo.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/