### PR TITLE
Fix for GitHub Action

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET Core environment 
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
 
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Setup .NET Core environment 
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0'
+        dotnet-version: '8.0'
 
     - name: Set up MSBuild
       uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
The latest version of `Microsoft.PowerApps.CLI.Tool` appears to have dropped support for dotnet 6.0. Updating to 8.0.

https://www.nuget.org/packages/Microsoft.PowerApps.CLI.Tool#supportedframeworks-body-tab

Maybe we should lock the version... however making sure the tools we use break when out of date is probably a good way to prevent dependence on an out of date tool/library.